### PR TITLE
Fixed skybox

### DIFF
--- a/src/SceneObjects.cpp
+++ b/src/SceneObjects.cpp
@@ -54,11 +54,16 @@ void SceneObjects::InitGrid() {
 
 	}
 }
-void SceneObjects::DrawScene() {
+void SceneObjects::DrawScene(bool drawSkyBox) {
 	bool check = DrawCourt();
 	if (!check) printf("Draw Court failed");
-	//check = DrawSkyBox();
-	//if (!check) printf("Draw DrawSkyBox failed");
+
+	// Make sure not to use the skybox itself when rendering shadows
+	if (drawSkyBox)
+	{
+		check = DrawSkyBox();
+		if (!check) printf("Draw DrawSkyBox failed");
+	}
 	//check = DrawGrid();
 	//if (!check) printf("Draw DrawGrid failed");
 	check = DrawCoord();

--- a/src/SceneObjects.h
+++ b/src/SceneObjects.h
@@ -56,6 +56,6 @@ public:
 	bool DrawSkyBox();
 	bool DrawGrid();
 	bool DrawCoord();
-	void DrawScene();
+	void DrawScene(bool drawSkyBox);
 };
 

--- a/src/main2.cpp
+++ b/src/main2.cpp
@@ -504,7 +504,7 @@ int main(int argc, char* argv[])
             SceneObj.sphereVertCount = vertexIndicessphere.size();
             SceneObj.SetAttr(rotationMatrixW, renderAs, shaderProgram);
             SceneObj.SetVAO(unitCubeAO, gridAO);
-            SceneObj.DrawScene();
+            SceneObj.DrawScene(false);  // Draw scene without the skybox, so it can't be used to make shadows on the scene
 
             // Unbind geometry
             glBindVertexArray(0);
@@ -540,8 +540,8 @@ int main(int argc, char* argv[])
             SceneObj.sphereVertCount = vertexIndicessphere.size();
             SceneObj.SetAttr(rotationMatrixW, renderAs, shaderProgram);
             SceneObj.SetVAO(unitCubeAO, gridAO);
-            SceneObj.DrawScene();
-            
+            SceneObj.DrawScene(true);  // Draw scene with the skybox
+
 			// Unbind geometry
             glBindVertexArray(0);
         }


### PR DESCRIPTION
Skybox is not longer used to make shadows in the first pass of drawing the scene. It used to be that the skybox itself would cast shadows on the scene.

Closes #34 